### PR TITLE
Disable API key prompt for graph

### DIFF
--- a/app/pkg/initialization/RunInit.go
+++ b/app/pkg/initialization/RunInit.go
@@ -38,19 +38,21 @@ func RunInit(noInputs bool, initData InitData, localRun bool) (bool, InitData, e
 	// Authentication
 	ux.PrintFormatted("\n→", []string{"blue", "bold"})
 	ux.PrintFormatted(" Authentication\n", []string{"white", "bold"})
-	if initData.APIKey == "" && (localRun || !noInputs) {
+	if initData.APIKey == "" && !noInputs && !localRun {
 		ux.PrintFormatted("  ⠿", []string{"blue", "bold"})
 		fmt.Print(" Enter API Key (You can find it in the Dashboard user settings https://app.pluralith.com/#/user/settings): ")
 		fmt.Scanln(&initData.APIKey) // Capture user input
 	}
 
-	// Run login routine and set credentials file
-	loginValid, loginErr := auth.RunLogin(initData.APIKey)
-	if loginErr != nil {
-		return false, initData, fmt.Errorf("failed to authenticate -> %v: %w", functionName, loginErr)
-	}
-	if !loginValid {
-		return false, initData, nil
+	// Run login routine and set credentials file if an API key was provided
+	if initData.APIKey != "" {
+		loginValid, loginErr := auth.RunLogin(initData.APIKey)
+		if loginErr != nil {
+			return false, initData, fmt.Errorf("failed to authenticate -> %v: %w", functionName, loginErr)
+		}
+		if !loginValid {
+			return false, initData, nil
+		}
 	}
 
 	if localRun {

--- a/app/pkg/plan/CreatePlanJson.go
+++ b/app/pkg/plan/CreatePlanJson.go
@@ -46,7 +46,7 @@ func ConvertBinaryPlanToJson(planPath string) (string, error) {
 	functionName := "ConvertBinaryPlanToJson"
 
 	// Constructing command to execute
-	cmd := exec.Command("terraform", append([]string{"show", "-json", planPath})...)
+	cmd := exec.Command("terraform", "show", "-json", planPath)
 
 	// Defining sinks for std data
 	var outputSink bytes.Buffer


### PR DESCRIPTION
## Summary
- skip RunInit authentication when no API key is supplied for local runs
- fix vet issue in CreatePlanJson

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_685d3baa47f48325bcfa0f25320d877f